### PR TITLE
Get problem by id and print problem id when testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 answers/*
+.nrepl-port

--- a/4bb.clj
+++ b/4bb.clj
@@ -58,7 +58,10 @@
   (let [name     (.getName answer)
         n        (Integer/parseInt name)
         ans      (slurp answer)
-        problem  (problems (dec n))
+        problem (some (fn [{id :_id :as p}]
+                        (when (= id n)
+                          p))
+                      problems)
         tests    (:tests problem)
         replaced (mapv #(str/replace % "__" ans) tests)]
     (if (= "" ans) false

--- a/tests.clj
+++ b/tests.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.set]
             [clojure.string :as str]
-            [clojure.test :as t :refer [deftest is]]))
+            [clojure.test :as t :refer [deftest is testing]]))
 
 (declare problems)
 (load-file "problems.clj")
@@ -17,11 +17,15 @@
     (let [name (.getName answer-file)
           n (Integer/parseInt name)
           ans (slurp answer-file)
-          problem (problems (dec n))
+          problem (some (fn [{id :_id :as p}]
+                          (when (= id n)
+                            p))
+                        problems)
           tests (:tests problem)
           replaced (mapv #(str/replace % "__" ans) tests)]
-      (doseq [test replaced]
-        (is (eval (read-string test)))))))
+      (testing (str "Running tests for the problem " n)
+        (doseq [test replaced]
+          (is (eval (read-string test))))))))
 
 (let [report (t/run-tests)]
   (System/exit (+ (:fail report)


### PR DESCRIPTION
If you get the problem indexing in the collection this can cause unexpected behavior when the problem vector is not ordered and the problems list is not consecutive like on the 4clojure website.

Note that problem[59] is the Problem #66 "Greatest Common Divisor".

It is also useful when a test fails to see what problem it refers to.
<img width="269" alt="image" src="https://user-images.githubusercontent.com/25042103/78507496-48c13f00-774e-11ea-887b-0120573aa068.png">
